### PR TITLE
Look for Sakefile in parent folders as well

### DIFF
--- a/META6.json
+++ b/META6.json
@@ -8,6 +8,6 @@
         "Sake": "lib/Sake.pm6"
     },
     "author"      : "Jonathan Scott Duff <duff@pobox.com>",
-    "depends"     : [],
+    "depends"     : ["File::Temp"],
     "source-url"  : "git://github.com/perl6/p6-sake.git"
 }

--- a/bin/sake
+++ b/bin/sake
@@ -6,7 +6,6 @@ use Sake;
 sub MAIN (*@tasks, :$file = 'Sakefile') {
     my $sake-file = look-for-sakefile($file.IO);
 
-    EVALFILE $sake-file;
     if @tasks < 1 {
         note ‘No tasks given! Did you mean one of these?’;
         note .indent: 4 for %Sake::TASKS.keys.sort;
@@ -16,17 +15,22 @@ sub MAIN (*@tasks, :$file = 'Sakefile') {
 }
 
 sub look-for-sakefile(IO::Path $path) {
-    return $path.absolute if $path.e;
-
-    my $cwd = $*CWD;
-    while (my $path-to-check = $cwd.parent) ne "/" {
-        my $file-to-check = $path-to-check.add('Sakefile');
-        if $file-to-check.e {
-            return $file-to-check.absolute;
-        }
-
-        $cwd = $path-to-check;
+    if $path.e {
+        EVALFILE $path.absolute;
     }
 
-    die "Could not find file $path!";
+    my $path-to-check = $*CWD;
+    # Use repeat otherwise 'ne /' would end the loop before the sake file would be searched in '/'
+    repeat {
+        $path-to-check = $path-to-check.parent;
+        my $file-to-check = $path-to-check.add('Sakefile');
+        if $file-to-check.e {
+            EVALFILE $file-to-check.absolute;
+        }
+
+    } while $path-to-check ne "/";
+
+    if not has-tasks() {
+        die "No Sakefiles found";
+    }
 }

--- a/bin/sake
+++ b/bin/sake
@@ -4,8 +4,9 @@ use v6;
 use Sake;
 
 sub MAIN (*@tasks, :$file = 'Sakefile') {
+    my $sake-file = look-for-sakefile($file.IO);
 
-    EVALFILE $file;
+    EVALFILE $sake-file;
     if @tasks < 1 {
         note ‘No tasks given! Did you mean one of these?’;
         note .indent: 4 for %Sake::TASKS.keys.sort;
@@ -17,12 +18,14 @@ sub MAIN (*@tasks, :$file = 'Sakefile') {
 sub look-for-sakefile(IO::Path $path) {
     return $path.absolute if $path.e;
 
-    while my $parent = $path.parent {
-        $parent = $parent.add('Sakefile');
-
-        if $parent.e {
-            return $parent.absolute;
+    my $cwd = $*CWD;
+    while (my $path-to-check = $cwd.parent) ne "/" {
+        my $file-to-check = $path-to-check.add('Sakefile');
+        if $file-to-check.e {
+            return $file-to-check.absolute;
         }
+
+        $cwd = $path-to-check;
     }
 
     die "Could not find file $path!";

--- a/bin/sake
+++ b/bin/sake
@@ -4,7 +4,7 @@ use v6;
 use Sake;
 
 sub MAIN (*@tasks, :$file = 'Sakefile') {
-    my $sake-file = look-for-sakefile($file.IO);
+    look-for-sakefiles($file.IO);
 
     if @tasks < 1 {
         note ‘No tasks given! Did you mean one of these?’;
@@ -14,23 +14,4 @@ sub MAIN (*@tasks, :$file = 'Sakefile') {
     for @tasks -> $t { execute($t); }
 }
 
-sub look-for-sakefile(IO::Path $path) {
-    if $path.e {
-        EVALFILE $path.absolute;
-    }
 
-    my $path-to-check = $*CWD;
-    # Use repeat otherwise 'ne /' would end the loop before the sake file would be searched in '/'
-    repeat {
-        $path-to-check = $path-to-check.parent;
-        my $file-to-check = $path-to-check.add('Sakefile');
-        if $file-to-check.e {
-            EVALFILE $file-to-check.absolute;
-        }
-
-    } while $path-to-check ne "/";
-
-    if not has-tasks() {
-        die "No Sakefiles found";
-    }
-}

--- a/bin/sake
+++ b/bin/sake
@@ -4,7 +4,7 @@ use v6;
 use Sake;
 
 sub MAIN (*@tasks, :$file = 'Sakefile') {
-    die "Could not find file $file!" unless $file.IO ~~ :e;
+
     EVALFILE $file;
     if @tasks < 1 {
         note ‘No tasks given! Did you mean one of these?’;
@@ -12,4 +12,18 @@ sub MAIN (*@tasks, :$file = 'Sakefile') {
         exit 1
     }
     for @tasks -> $t { execute($t); }
+}
+
+sub look-for-sakefile(IO::Path $path) {
+    return $path.absolute if $path.e;
+
+    while my $parent = $path.parent {
+        $parent = $parent.add('Sakefile');
+
+        if $parent.e {
+            return $parent.absolute;
+        }
+    }
+
+    die "Could not find file $path!";
 }

--- a/lib/Sake.pm6
+++ b/lib/Sake.pm6
@@ -71,3 +71,7 @@ multi sub file(Pair $name-deps, &body) {
         :cond($cond)
     )
 }
+
+sub has-tasks() is export {
+    return %TASKS.keys.elems > 0;
+}

--- a/lib/Sake.pm6
+++ b/lib/Sake.pm6
@@ -53,7 +53,7 @@ multi sub file(Str $name, &body) {
     return make-task(
         $name,
         { &body($_); touch $name },
-        :cond(sub { $name.path !~~ :e; })
+        :cond(sub { $name.IO !~~ :e; })
     )
 }
 

--- a/t/01-look-for-sakefiles.t
+++ b/t/01-look-for-sakefiles.t
@@ -1,0 +1,49 @@
+use v6;
+use Test;
+use Sake;
+
+use File::Temp;
+
+
+# Test the feature to look for the Sakefile not only in the current working directory but also in the parents until
+# up to the root folder.
+
+my $no-sakefile-dir = tempdir;
+my $cwd = chdir($no-sakefile-dir);
+dies-ok {look-for-sakefiles("Sakefile".IO)}, "Dies when no Sakefile was found";
+chdir($cwd);
+
+# Test that the same task in parent sakefiles does not overwrite the "nearest" one
+my ($test-result-name, $test-result-fh) = tempfile();
+my $parent-dir = create-dir-and-file(file-to-write => $test-result-name,
+        what-to-write => "parent");
+
+my ($file-name, $file-fh) = create-dir-and-file(parent => $parent-dir,
+        file-to-write => $test-result-name,
+        what-to-write => "test");
+
+look-for-sakefiles($file-fh.IO);
+
+execute("test");
+
+is  $test-result-fh.slurp, "test", "Nearest task is used";
+
+# Clean tasks hash for following tests.
+%Sake::TASKS = %();
+
+done-testing;
+
+sub create-dir-and-file(:$parent, :$file-to-write, :$what-to-write) {
+    my $dir = $parent ?? tempdir(tempdir => $parent) !! tempdir;
+
+    my ($file-name, $file-fh) = tempfile("Sakefile", tempdir => $dir);
+    my $test-task = qq:to/END/;
+        task 'test', \{
+    $file-to-write.IO.spurt("$what-to-write");
+}
+END
+
+    $file-fh.spurt($test-task);
+
+    return ($file-name, $file-fh);
+}


### PR DESCRIPTION
My idea was to be able to have not just one Sakefile in the current folder, instead Sakefiles in parent folders should be find as well. That has the benefit, that tasks can be available or overwritten depending of the current working folder.

For that, I added a method to the pm file plus a test file to test it.
Changed the behavior though. Sake no longer dies if a task already exists. It just ignores the task found in parent folders with the same name. So, always the task is used that is the nearest to the current working dir. That might be not the desired approach for other users.